### PR TITLE
BRD-28: Implement routers folder structure. Add endpoints structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "client": "webpack-dev-server --mode development",
-    "server": "babel-node src/server/app",
+    "server": "babel-node src/server/index",
     "build-dev": "webpack --mode development",
     "start-dev": "concurrently \"npm run server\" \"npm run client\""
   },

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -3,19 +3,18 @@ import cors from 'cors';
 import bodyParser from 'body-parser';
 
 // local imports
-import config from '../config/core';
-import logger from '../logger'
+import itemsRouter from './routers/items';
+import setsRouter from './routers/sets';
 
-const port = config.serverPort || 5000;
 const app = express();
 
 // bodyParser allows POST requests
 app.use(
   cors(),
   bodyParser.urlencoded({extended: true}),
-  bodyParser.json()
+  bodyParser.json(),
+  itemsRouter,
+  setsRouter
 );
 
-app.listen(port, () => {
-  logger.info(`Server Listening on Port: ${port}`);
-});
+module.exports = app;

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,0 +1,9 @@
+import app from './app';
+import config from '../config/core';
+import logger from '../logger';
+
+const port = config.serverPort || 5000;
+
+app.listen(port, () => {
+  logger.info(`Server Listening on Port: ${port}`);
+});

--- a/src/server/routers/items.js
+++ b/src/server/routers/items.js
@@ -1,0 +1,26 @@
+import express from 'express';
+
+// local imports
+import logger from '../../logger';
+
+const router = new express.Router();
+
+router.get('/api/datasets/:name/items/:id', (req, res) => {
+  logger.info(`Fetching dataset ${req.params.name} item: ${req.params.id}`);
+  res.status(200).json({"id": "1", "iso": "PRT", "name": "Portugal"})
+});
+
+router.post('/api/datasets/:name/items', (req, res) => {
+  logger.info(`Creating new data item in dataset ${req.params.name}`);
+
+});
+
+router.patch('/api/datasets/items/:id', (req, res) => {
+  logger.info(`Patching dataset ${req.params.name} item: ${req.params.id}`);
+});
+
+router.delete('/api/datasets/items/:id', (req, res) => {
+  logger.info(`Deleting dataset ${req.params.name} item: ${req.params.id}`);
+});
+
+module.exports = router;

--- a/src/server/routers/sets.js
+++ b/src/server/routers/sets.js
@@ -1,0 +1,47 @@
+import express from 'express';
+
+// local imports
+import logger from '../../logger'
+
+const router = new express.Router();
+
+router.get('/api/datasets', (req, res) => {
+  logger.info('Fetching datasets');
+  res.status(200).json(
+    [
+      {
+        "id": "1",
+        "iso": "PRT",
+        "name": "Portugal"
+      },
+      {
+        "id": "2",
+        "iso": "GBR",
+        "name": "Great Britain"
+      }
+    ]
+  )
+});
+
+router.get('/api/datasets/:name', (req, res) => {
+  logger.info(`Fetching dataset ${req.params.name}`);
+
+});
+
+router.get('/api/datasets/:name/schema', (req, res) => {
+  logger.info(`Fetching dataset ${req.params.name} schema`);
+});
+
+router.get('/api/datasets/:name/search?', (req, res) => {
+  logger.info(`Searching datasets ${req.params.name}`);
+});
+
+router.patch('/api/datasets/:name', (req, res) => {
+  logger.info(`Patching dataset ${req.params.name}`);
+});
+
+router.delete('/api/datasets/:name', (req, res) => {
+  logger.info(`Deleting dataset ${req.params.name}`);
+});
+
+module.exports = router;


### PR DESCRIPTION
* Implement routers folder structure;
* Add endpoint structure

To test:
* pull branch;
* `npm install`;
* `npm run build-dev`;
* `npm run server` (runs only the server, but you can also run `npm run start-dev`, works either way);
* open your browser and hit `http://localhost:5000/api/datasets` or `http://localhost:5000/api/datasets/portugal/items/2` you should see the logs