### PR TITLE
Force READ_ONLY_MODE to be a string in kube deployment

### DIFF
--- a/kube/deployment.yml
+++ b/kube/deployment.yml
@@ -47,7 +47,7 @@ spec:
           - name: API_BASE_URL
             value: {{.API_BASE_URL}}
           - name: READ_ONLY_MODE
-            value: {{.READ_ONLY_MODE}}
+            value: '{{.READ_ONLY_MODE}}'
 
       - name: proxy
         image: quay.io/ukhomeofficedigital/nginx-proxy


### PR DESCRIPTION
### Problem
The kube deployment is treating the injected env var READ_ONLY_MODE as a boolean in the yaml (when the value is set to either true or false)

### Solution
Put quotes around the env var value that `kd` is injecting