### PR TITLE
Adds sending deployment notifications to Slack

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -131,13 +131,13 @@ pipeline:
     channel: cop-deployments
     username: Drone Build Watcher
     template: >
-        {{#success build.status}}
-          *{{repo.name}} - Build {{build.number}} succeeded*
-          {{build.link}}
-        {{else}}
-          *{{repo.name}} - Build {{build.number}} failed*
-          {{build.link}}
-        {{/success}}
+      {{#build.deployTo}}
+        *{{repo.name}} - Build {{build.number}} - {{uppercasefirst build.deployTo}} - {{uppercase build.status}}*
+        {{build.link}}
+      {{else}}
+        *{{repo.name}} - Build {{build.number}} - Development - {{uppercase build.status}}*
+        {{build.link}}
+      {{/build.deployTo}}
     when:
       branch: master
       event: [ push, deployment ]

--- a/.drone.yml
+++ b/.drone.yml
@@ -124,3 +124,21 @@ pipeline:
     when:
       event: deployment
       environment: production
+
+  notify:
+    image: plugins/slack
+    secrets: [ SLACK_WEBHOOK ]
+    channel: cop-deployments
+    username: Drone Build Watcher
+    template: >
+        {{#success build.status}}
+          *{{repo.name}} - Build {{build.number}} succeeded*
+          {{build.link}}
+        {{else}}
+          *{{repo.name}} - Build {{build.number}} failed*
+          {{build.link}}
+        {{/success}}
+    when:
+      branch: master
+      event: [ push, deployment ]
+      status: [ success, failure ]


### PR DESCRIPTION
Adds a build step at the end of the drone pipeline to publish a notification to a Slack channel showing the build status and a link to the build on Drone.
